### PR TITLE
Added VERSIONING.md

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,32 @@
+# About Versioning
+
+This guidelines apply to versioning of docker images in mailserver2 repos:
+
+- mailserver
+- debian-mail-overlay
+- postfixadmin
+- rainloop
+
+Historically the old [hardware/debian-mail-overlay](https://hub.docker.com/r/hardware/debian-mail-overlay/tags) image seemed to be versioned after `rspamd` it includes. However, apart of `rspamd` the image contains a lot of other differently versioned software. In this regard, it's more logical to have an independent version, and note down the version of individual software component in the commit messages and/or release history. 
+
+For `rainloop` and `postfixadmin` it makes sense to continue to version the images after the respective software versions, since it's not likely that they may require a version bump for any other reason.
+
+In certain case it's also possible for the `Dockerfile` itself to change without individual components updates. Finally, it could be that the `Dockerfile` does not change either, but the change is effected by update in an upstream software repository, for example `clamav` updates in `mailserver` are handled this way.
+
+Follow these steps when an update is ready to be pushed to Docker Hub:
+
+- Tag the current GitHub commit in the `mailserver2` repo with the next version, e.g. `git tag -a v1.0.1 -m "update postfixadmin to version 1.0.1, ... other changes here"`
+- Build the new image
+- Label it with the version you tagged the current commit with
+- Push this image version with the label above as well as with the `latest` label
+
+## Build Example
+
+```
+docker build . -t debian-mail-overlay
+docker tag debian-mail-overlay mailserver2/debian-mail-overlay:0.0.0
+docker push mailserver2/debian-mail-overlay:0.0.0
+docker tag debian-mail-overlay mailserver2/debian-mail-overlay:latest
+docker push mailserver2/debian-mail-overlay:latest
+```
+


### PR DESCRIPTION
## Description

This commit proposes versioning scheme for `mailserver2` images.
Fixes https://github.com/mailserver2/mailserver/issues/8

* What is the current behavior (you can also link to an open issue here) ?
Currently we always push to `latest` in Docker Hub
* What is the new behavior (if this is a feature change) ?
Tag version in Github, push that version to Docker Hub and tag it as `latest`

## Type of change

- [X] Documentation only

## Status
- [X] Ready

## How has this been tested ?

Sine this is a documentation change at this stage, unit tests are irrelevant. However since it proposes changes in the process this is expected to be peer reviewed before getting merged.

## What's next ?

Once this change is merged the current versions in Docker Hub can be fixed in the following manner:

```
docker pull mailserver2/mailserver
docker tag mailserver2/mailserver mailserver2/mailserver:1.1.1
docker push mailserver2/mailserver:1.1.1

docker pull mailserver2/postfixadmin
docker tag mailserver2/postfixadmin mailserver2/postfixadmin:3.2.4
docker push mailserver2/postfixadmin:3.2.4

docker pull mailserver2/rainloop
docker tag mailserver2/rainloop mailserver2/rainloop:1.14.0
docker push mailserver2/rainloop:1.14.0

docker pull mailserver2/debian-mail-overlay
docker tag mailserver2/debian-mail-overlay mailserver2/debian-mail-overlay:1.0.0
docker mailserver2/debian-mail-overlay:1.0.0
```

I'm happy to do the change after it's merged, or feel free to do it yourself. The Wiki also might need updating.

It's probably too late to tag GitHub repos with this versions now, but it should be done for each subsequent Docker Hub push.