### PR TITLE
updated enviroment, compose and docker files with version references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM mailserver2/debian-mail-overlay:latest
+FROM mailserver2/debian-mail-overlay:1.0.0
 
-LABEL description="Simple and full-featured mail server using Docker" \
-      maintainer="Hardware <contact@meshup.net>"
+LABEL description="Simple and full-featured mail server using Docker"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -33,7 +33,7 @@ services:
       - http_network
 
   mailserver:
-    image: hardware/mailserver:${MAILSERVER_DOCKER_TAG}
+    image: mailserver2/mailserver:${MAILSERVER_DOCKER_TAG}
     restart: ${RESTART_MODE}
     domainname: ${MAILSERVER_DOMAIN}                    # Mail server A/MX/FQDN & reverse PTR = mail.domain.tld.
     hostname: ${MAILSERVER_HOSTNAME}
@@ -82,7 +82,7 @@ services:
   # http://postfixadmin.sourceforge.net/
   # Configuration : https://github.com/hardware/mailserver/wiki/Postfixadmin-initial-configuration
   postfixadmin:
-    image: hardware/postfixadmin
+    image: mailserver2/postfixadmin:${POSTFIXADMIN_DOCKER_TAG}
     restart: ${RESTART_MODE}
     domainname: ${MAILSERVER_DOMAIN}
     hostname: ${MAILSERVER_HOSTNAME}
@@ -105,7 +105,7 @@ services:
   # https://www.rainloop.net/
   # Configuration : https://github.com/hardware/mailserver/wiki/Rainloop-initial-configuration
   rainloop:
-    image: hardware/rainloop
+    image: mailserver2/rainloop:${RAINLOOP_DOCKER_TAG}
     restart: ${RESTART_MODE}
     labels:
       - traefik.enable=true

--- a/sample.env
+++ b/sample.env
@@ -24,15 +24,11 @@ RSPAMD_PASSWORD=
 MAILSERVER_HOSTNAME=mail
 
 # Mailserver version
-# 1.1-stable : Stable version (v1.1-stable github branch)
-# 1.1-latest : Latest development build (master github branch)
-# Latest development builds have been validated through
-# the CI automation system but they are not meant for
-# deployment in production.
-# 1.1-stable and 1.1-latest are rebuilt weekly on the docker hub but if you
-# have any problem with a new build you can switch to 1.1-stable-fallback
-# The fallback tag is rebuilt monthly.
-MAILSERVER_DOCKER_TAG=1.1-stable
+MAILSERVER_DOCKER_TAG=1.1.1
+
+POSTFIXADMIN_DOCKER_TAG=3.2.4
+
+RAINLOOP_DOCKER_TAG=1.14.0
 
 # Docker volumes parent folder
 VOLUMES_ROOT_PATH=/mnt/docker


### PR DESCRIPTION
## Description

Now, when we have https://github.com/mailserver2/mailserver/pull/11 merged, we can add version references in the appropriate files:

* Add postfixadmin and rainloop version into sample environment file
* Add those versions into docker-compose sample file
* Change docker-compose sample file to use `mailserver2` instead of `hardware` images on Docker Hub where appropriate
* Change Dockerfile to reference a specific version of the base image

## Type of change
- [X] Refactoring (a change that neither fixes a bug nor adds a feature)

## Status

- [X] Ready

## How has this been tested ?

Samples files are not being tested by unit tests, we will rely on the community feedback if there is an issue. Dockerfile change will be tested by running the travisCI build.