### PR TITLE
Added compression to Dovecot IMAP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     python3-pip python3-setuptools python3-wheel python3-gpg \
     rsyslog dnsutils curl unbound jq rsync \
     inotify-tools \
+    # To enable compression in imap
+    arj bzip2 cabextract cpio file gzip nomarch pax unzip zip \
  && rm -rf /var/spool/postfix \
  && ln -s /var/mail/postfix/spool /var/spool/postfix \
  && apt-get autoremove -y \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ init:
 	-docker rm -f \
 		mariadb postgres redis openldap \
 		mailserver_default mailserver_reverse mailserver_ecdsa mailserver_ldap mailserver_ldap2 \
-		mailserver_traefik_acmev1 mailserver_traefik_acmev2
+		mailserver_traefik_acmev1 mailserver_traefik_acmev2 || true
 
 	sleep 2
 

--- a/rootfs/etc/dovecot/conf.d/10-mail.conf
+++ b/rootfs/etc/dovecot/conf.d/10-mail.conf
@@ -1,4 +1,4 @@
-mail_plugins = $mail_plugins quota
+mail_plugins = $mail_plugins quota zlib
 mail_location = maildir:/var/mail/vhosts/%d/%n/{{ .VMAIL_SUBDIR }}
 maildir_stat_dirs=yes
 
@@ -13,3 +13,8 @@ first_valid_uid = {{ .VMAILUID }}
 last_valid_uid = {{ .VMAILUID }}
 
 mail_privileged_group = vmail
+
+plugin {
+  zlib_save_level = 6 # 1..9
+  zlib_save = gz # or bz2, If this config entry missing, compression is disabled. 
+}

--- a/rootfs/etc/dovecot/conf.d/20-imap.conf
+++ b/rootfs/etc/dovecot/conf.d/20-imap.conf
@@ -2,7 +2,7 @@ imap_idle_notify_interval = 4 mins
 
 protocol imap {
 
-  mail_plugins = $mail_plugins imap_quota imap_sieve
+  mail_plugins = $mail_plugins imap_quota imap_sieve imap_zlib zlib
   imap_client_workarounds = tb-extra-mailbox-sep
   mail_max_userip_connections = 20
 

--- a/rootfs/etc/dovecot/conf.d/20-imap.conf
+++ b/rootfs/etc/dovecot/conf.d/20-imap.conf
@@ -2,7 +2,7 @@ imap_idle_notify_interval = 4 mins
 
 protocol imap {
 
-  mail_plugins = $mail_plugins imap_quota imap_sieve imap_zlib zlib
+  mail_plugins = $mail_plugins imap_quota imap_sieve imap_zlib
   imap_client_workarounds = tb-extra-mailbox-sep
   mail_max_userip_connections = 20
 

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1777,13 +1777,13 @@ load 'test_helper/bats-assert/load'
 }
 
 @test "checking zeyple: 3 emails encrypted in john.doe folder" {
-  run docker exec mailserver_reverse /bin/sh -c "grep -i 'multipart/encrypted' /var/mail/vhosts/domain.tld/john.doe/subdir/new/* | wc -l"
+  run docker exec mailserver_reverse /bin/sh -c "gzip -cd /var/mail/vhosts/domain.tld/john.doe/subdir/new/* | grep -i 'multipart/encrypted' | wc -l"
   assert_success
   assert_output 3
-  run docker exec mailserver_reverse /bin/sh -c "grep -i 'BEGIN PGP MESSAGE' /var/mail/vhosts/domain.tld/john.doe/subdir/new/* | wc -l"
+  run docker exec mailserver_reverse /bin/sh -c "gzip -cd /var/mail/vhosts/domain.tld/john.doe/subdir/new/* | grep -i 'BEGIN PGP MESSAGE' | wc -l"
   assert_success
   assert_output 3
-  run docker exec mailserver_reverse /bin/sh -c "grep -i 'END PGP MESSAGE' /var/mail/vhosts/domain.tld/john.doe/subdir/new/* | wc -l"
+  run docker exec mailserver_reverse /bin/sh -c "gzip -cd /var/mail/vhosts/domain.tld/john.doe/subdir/new/* | grep -i 'END PGP MESSAGE' | wc -l"
   assert_success
   assert_output 3
 }


### PR DESCRIPTION
## Description

I added compression to the Dovecot IMAP service.  So we can save up some storage in our system.  In my ancient email system before this solution, my IMAP service used compression.  To use this image in my system, I have to enable the compression for IMAP service.  Also, when we merge these changes, we can save storage usage, but we will lose the pain text readability for each IMAP's email from the command line.

## Fixes # (issue)

* What is the current behavior (you can also link to an open issue here)?
As I mentioned in the description section, the current setup stores all emails in plain text without compression.

* What is the new behavior (if this is a feature change) ?
Using `imap_zlip` and `zlib` plugins from Dovecot IMAP service so we can save storage space moving forward. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only
- [ ] Performance improvement
- [ ] Refactoring (a change that neither fixes a bug nor adds a feature)
- [x] Test (adding missing tests or correcting existing ones)
- [ ] Other... 

## Status

- [x] Ready
- [ ] In development
- [ ] Hold

## Todo List
- [ ] Implementation
- [ ] Tests
- [ ] Documentation
- [ ] ...

## How has this been tested ?

I ran the `make` command on my local machine, and I will check `Travis` as well.

- [ ] Test A
- [ ] Test B