### PR TITLE
Tests: update osixia/openldap docker image to version 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
+## Unreleased
+
+* Tests: updated osixia/openldap docker image to version [1.4.0](https://github.com/osixia/docker-openldap/releases/tag/v1.4.0).
+
 ## v1.1.2
 
 ### New features
 
-* Added compression to Dovecot IMAP ([#13](https://github.com/mailserver2/mailserver/pull/13))
+* Added compression to Dovecot IMAP ([#13](https://github.com/mailserver2/mailserver/pull/13)).
 
 ## v1.1.1
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ init:
 		-e LDAP_ADMIN_PASSWORD="testpasswd" \
 		-e LDAP_TLS=false \
 		-v "`pwd`/test/config/ldap/struct.ldif":/container/service/slapd/assets/config/bootstrap/ldif/custom/struct.ldif \
-		-t osixia/openldap:1.3.0 --copy-service
+		-t osixia/openldap:1.4.0 --copy-service
 
 	sleep 10
 


### PR DESCRIPTION
## Description

I updated osixia/openldap docker image to version 1.4.0.

## Status

- [X] Ready