### PR TITLE
Fix certificate watching (auto renew).

### DIFF
--- a/rootfs/usr/local/bin/certs_helper.sh
+++ b/rootfs/usr/local/bin/certs_helper.sh
@@ -144,8 +144,8 @@ elif [ "$1" = "update_certs" ]; then
   _normalize_certs "$NORMALIZED_CERT_PATH"
   [ $? -ne 0 ] && exit 1
 
-  # Compare Old and New key
-  if cmp --silent "$NORMALIZED_CERT_PATH"/privkey.pem "$LIVE_CERT_PATH"/privkey.pem; then
+  # Compare old and new certificates
+  if cmp --silent "$NORMALIZED_CERT_PATH"/fullchain.pem "$LIVE_CERT_PATH"/fullchain.pem; then
     echo "[INFO] Live Certificates match"
     rm -rf "$CERT_TEMP_PATH"
     exit 1


### PR DESCRIPTION
## Description

This feature has been introduced on https://github.com/hardware/mailserver/pull/366 and has a quite simple error that went unnoticed.
This PR fix this error so the certificate can be automatically reloaded.

The problem is that Traefik reuses the same private key when renewing it's certificates (Who would have guessed that !?).

```go
// Renew takes a Resource and tries to renew the certificate.
//
// If the renewal process succeeds, the new certificate will be returned in a new CertResource.
// Please be aware that this function will return a new certificate in ANY case that is not an error.
// If the server does not provide us with a new cert on a GET request to the CertURL
// this function will start a new-cert flow where a new certificate gets generated.
//
// If bundle is true, the []byte contains both the issuer certificate and your issued certificate as a bundle.
//
// For private key reuse the PrivateKey property of the passed in Resource should be non-nil.
```
Source: https://pkg.go.dev/github.com/plgd-dev/kit/security/certManager/acme/client#Certifier.Renew

**Traefik v1:**
https://github.com/traefik/traefik/blob/d1befe7b122c6f5e95d730936c0993ca456fd071/provider/acme/provider.go#L653

**Traefik v2:**
https://github.com/traefik/traefik/blob/3506cbd5e9ad2587fe32bacc0c2410cd00e72974/pkg/provider/acme/provider.go#L631

That is why the certificate gets automatically renewed, but the comparision always says "Live Certificates match",  when it is not true.
Sure the private key matches, but the certificate and the full chain certificate files are different.

So, the fix is pretty simple, let's compare the `fullchain.pem` to avoid this kind of issue.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Status

- [X] Ready
