### PR TITLE
fixing some more log rotation warnings

### DIFF
--- a/rootfs/usr/local/bin/setup.sh
+++ b/rootfs/usr/local/bin/setup.sh
@@ -758,7 +758,9 @@ fi
 # ---------------------------------------------------------------------------------------------
 
 # Remove invoke-rc.d warning
-sed -i 's|rsyslog-rotate|rsyslog-rotate \&>/dev/null|g' /etc/logrotate.d/rsyslog
+sed -i 's|invoke-rc.d rsyslog rotate|s6-svc -h /services/rsyslogd|g' /usr/lib/rsyslog/rsyslog-rotate
+sed -i 's|invoke-rc.d clamav-daemon reload-log|s6-svc -h /services/clamd|g' /etc/logrotate.d/clamav-daemon
+sed -i 's|invoke-rc.d clamav-freshclam reload-log|s6-svc -h /services/freshclam|g' /etc/logrotate.d/clamav-freshclam
 
 # Folders and permissions
 mkdir -p /var/run/fetchmail


### PR DESCRIPTION
## Description

Fixes https://github.com/mailserver2/mailserver/issues/24

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Status

- [X] In development

## Todo List
- [X] Implementation
- [X] Testing

## How has this been tested ?

`docker-compose up -d --force-recreate` with the new image; `docker exec -it mailserver bash`, inside the container run `/usr/sbin/logrotate -f /etc/logrotate.conf`, confirm that there was no warnings.

An image is published in `andrewsav/mailserver:logrotate-1` with this change. @pollux will run it for awhile and will report their findings. Until then the PR will remain open.