### PR TITLE
Update base image to mailserver2/debian-mail-overlay:1.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mailserver2/debian-mail-overlay:1.0.6
+FROM mailserver2/debian-mail-overlay:1.0.7
 
 LABEL description="Simple and full-featured mail server using Docker"
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ init_postgres:
 		-e POSTGRES_USER=postfix \
 		-e POSTGRES_PASSWORD=testpasswd \
 		-v "`pwd`/test/config/postgres":/docker-entrypoint-initdb.d \
-		-t postgres:13-alpine
+		-t postgres:14-alpine
 
 init_ldap: init_openldap init_redis
 	-docker rm -f \


### PR DESCRIPTION
Simple update to the latest [debian-mail-overlay](https://github.com/mailserver2/debian-mail-overlay/releases/tag/v1.0.7) image.