### PR TITLE
Update base image to mailserver2/debian-mail-overlay:1.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mailserver2/debian-mail-overlay:1.0.7
+FROM mailserver2/debian-mail-overlay:1.0.8
 
 LABEL description="Simple and full-featured mail server using Docker"
 


### PR DESCRIPTION
Simple update to the latest [debian-mail-overlay](https://github.com/mailserver2/debian-mail-overlay/releases/tag/v1.0.8) image.