### PR TITLE
Update base image to mailserver2/debian-mail-overlay:1.0.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mailserver2/debian-mail-overlay:1.0.9
+FROM mailserver2/debian-mail-overlay:1.0.10
 
 LABEL description="Simple and full-featured mail server using Docker"
 


### PR DESCRIPTION
Simple update to the latest [debian-mail-overlay](https://github.com/mailserver2/debian-mail-overlay/releases/tag/v1.0.10) image.