### PR TITLE
Update to Bookworm (mailserver2/debian-mail-overlay:1.0.12)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     dovecot-core dovecot-imapd dovecot-lmtpd dovecot-pgsql dovecot-mysql dovecot-ldap dovecot-sieve dovecot-managesieved dovecot-pop3d \
     fetchmail libdbi-perl libdbd-pg-perl libdbd-mysql-perl liblockfile-simple-perl \
     clamav clamav-daemon \
-    python3-pip python3-setuptools python3-wheel python3-gpg \
+    python3-pip python3-setuptools python3-wheel python3-gpg python3-watchdog \
     rsyslog dnsutils curl unbound jq rsync \
     inotify-tools \
     # To enable compression in imap
@@ -19,8 +19,7 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
  && ln -s /var/mail/postfix/spool /var/spool/postfix \
  && apt-get autoremove -y \
  && apt-get clean \
- && rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/debconf/*-old \
- && pip3 install watchdog
+ && rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/debconf/*-old
 
 EXPOSE 25 143 465 587 993 4190 11334
 COPY rootfs /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mailserver2/debian-mail-overlay:1.0.11
+FROM mailserver2/debian-mail-overlay:1.0.12
 
 LABEL description="Simple and full-featured mail server using Docker"
 
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     fetchmail libdbi-perl libdbd-pg-perl libdbd-mysql-perl liblockfile-simple-perl \
     clamav clamav-daemon \
     python3-pip python3-setuptools python3-wheel python3-gpg python3-watchdog \
-    rsyslog dnsutils curl unbound jq rsync \
+    rsyslog dnsutils curl unbound unbound-anchor jq rsync \
     inotify-tools \
     # To enable compression in imap
     arj bzip2 cabextract cpio file gzip nomarch pax unzip zip \

--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,7 @@ init_ldap2: init_openldap init_redis
 		-t $(NAME)
 fixtures_ldap2:
 	docker exec mailserver_ldap2 /bin/sh -c "while ! echo PING | nc -z 0.0.0.0 25 ; do sleep 1 ; done"
+	sleep 30
 	docker exec mailserver_ldap2 /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-existing-user.txt"
 	docker exec mailserver_ldap2 /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-valid-user-subaddress.txt"
 	docker exec mailserver_ldap2 /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-non-existing-user.txt"

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ init_redis:
 	docker run \
 		-d \
 		--name redis \
-		-t redis:6.2-alpine
+		-t redis:7.0-alpine
 	sleep 10
 
 init_mariadb:
@@ -51,7 +51,7 @@ init_mariadb:
 		-e MYSQL_PASSWORD=testpasswd \
 		-v "`pwd`/test/config/mariadb/struct.sql":/docker-entrypoint-initdb.d/struct.sql \
 		-v "`pwd`/test/config/mariadb/bind.cnf":/etc/mysql/conf.d/bind.cnf \
-		-t mysql:5.7
+		-t mysql:8
 
 init_postgres:
 	-docker rm -f \
@@ -318,8 +318,8 @@ init_ecdsa: init_redis init_mariadb
 		-v "`pwd`/test/share/postfix/custom.ecdsa.conf":/var/mail/postfix/custom.conf \
 		-h mail.domain.tld \
 		-t $(NAME)
-	sleep 10
 run_ecdsa:
+	docker exec mailserver_ecdsa /bin/sh -c "while ! echo PING | nc -z 0.0.0.0 587 ; do sleep 1 ; done"
 	./test/bats/bin/bats test/ecdsa.bats
 stop_ecdsa:
 	-docker rm -f \
@@ -344,7 +344,7 @@ init_traefik_acmev1: init_redis init_mariadb
 		-h mail.domain.tld \
 		-t $(NAME)
 run_traefik_acmev1:
-	sleep 20
+	docker exec mailserver_traefik_acmev1 /bin/sh -c "while ! echo PING | nc -z 0.0.0.0 587 ; do sleep 1 ; done"
 	./test/bats/bin/bats test/traefik_acmev1.bats
 stop_traefik_acmev1:
 	-docker rm -f \
@@ -369,7 +369,7 @@ init_traefik_acmev2: init_redis init_mariadb
 		-h mail.domain.tld \
 		-t $(NAME)
 run_traefik_acmev2:
-	sleep 20
+	docker exec mailserver_traefik_acmev2 /bin/sh -c "while ! echo PING | nc -z 0.0.0.0 587 ; do sleep 1 ; done"
 	./test/bats/bin/bats test/traefik_acmev2.bats
 stop_traefik_acmev2:
 	-docker rm -f \

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ init_ldap2: init_openldap init_redis
 		-h mail.domain.tld \
 		-t $(NAME)
 fixtures_ldap2:
-	sleep 20
+	docker exec mailserver_ldap2 /bin/sh -c "while ! echo PING | nc -z 0.0.0.0 25 ; do sleep 1 ; done"
 	docker exec mailserver_ldap2 /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-existing-user.txt"
 	docker exec mailserver_ldap2 /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-valid-user-subaddress.txt"
 	docker exec mailserver_ldap2 /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-non-existing-user.txt"
@@ -282,6 +282,7 @@ init_reverse: init_redis init_postgres
 		-v "`pwd`/test/share/letsencrypt":/etc/letsencrypt \
 		-t $(NAME)
 fixtures_reverse:
+	docker exec mailserver_reverse /bin/sh -c "while ! echo PING | nc -z 0.0.0.0 25 ; do sleep 1 ; done"
 	sleep 30
 	docker exec mailserver_reverse /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-existing-user.txt"
 	docker exec mailserver_reverse /bin/sh -c "nc 0.0.0.0 25 < /tmp/tests/email-templates/external-to-valid-user-subaddress-with-default-separator.txt"

--- a/test/default.bats
+++ b/test/default.bats
@@ -626,7 +626,7 @@ load 'test_helper/bats-assert/load'
 #
 
 @test "checking clamav: TCP Bound to 3310 port" {
-  run docker exec mailserver_default grep -i 'TCP: Bound to \[0.0.0.0\]:3310' /var/log/mail.log
+  run docker exec mailserver_default grep -i 'TCP: Bound to \[\]:3310' /var/log/mail.log
   assert_success
 }
 
@@ -804,7 +804,7 @@ load 'test_helper/bats-assert/load'
 #
 
 @test "checking ssl: generated default cert works correctly" {
-  run docker exec mailserver_default /bin/sh -c "timeout 1 openssl s_client -ign_eof -connect 0.0.0.0:587 -starttls smtp | grep 'Verify return code: 18 (self signed certificate)'"
+  run docker exec mailserver_default /bin/sh -c "timeout 1 openssl s_client -ign_eof -connect 0.0.0.0:587 -starttls smtp | grep 'Verify return code: 18 (self-signed certificate)'"
   assert_success
 }
 

--- a/test/ecdsa.bats
+++ b/test/ecdsa.bats
@@ -26,7 +26,7 @@ load 'test_helper/bats-assert/load'
 #
 
 @test "checking ssl: ECDSA P-384 cert works correctly" {
-  run docker exec mailserver_ecdsa /bin/sh -c "timeout 1 openssl s_client -ign_eof -connect 0.0.0.0:587 -starttls smtp | grep 'Verify return code: 18 (self signed certificate)'"
+  run docker exec mailserver_ecdsa /bin/sh -c "timeout 1 openssl s_client -ign_eof -connect 0.0.0.0:587 -starttls smtp | grep 'Verify return code: 18 (self-signed certificate)'"
   assert_success
 }
 


### PR DESCRIPTION
## Description

Update to base image mailserver2/debian-mail-overlay:1.0.12 with debian bookworm.

## Type of change

- [X] Update

## Status

- [X] Ready
- [ ] In development
- [ ] Hold

## How has this been tested?

All tests are succeeding.