### PR TITLE
Update rsyslog.conf to ignore some rspamd warnings for tests

### DIFF
--- a/rootfs/etc/rsyslog/rsyslog.conf
+++ b/rootfs/etc/rsyslog/rsyslog.conf
@@ -7,6 +7,9 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 # https://github.com/vstakhov/rspamd/issues/1693
 :msg,contains,"map file is unavailable for reading" ~
 :msg,contains,"cannot load controller stats from /var/mail/rspamd/stats.ucl" ~
+:msg,contains,"rspamd_register_symbol_fromlua: duplicate symbol" ~
+:msg,contains,"trying to add virtual symbol MID" ~
+:msg,contains,"init of /usr/share/rspamd/lualib/lua_ffi/spf.lua failed" ~
 :msg,contains,"database is locked" ~
 :msg,contains,"http error occurred: IO read error: unexpected EOF" ~
 :msg,contains,"http error occurred: Not found" ~


### PR DESCRIPTION
@AndrewSav Ignoring these rspamd warning messages at rsyslog level should make the tests to pass. i did test locally with the ecdsa test : 

```
./test/bats/bin/bats test/ecdsa.bats
 ✓ checking rspamd: 3 modules disabled in ecdsa configuration
 ✓ checking rspamd: 2 addresses whitelisted in ecdsa configuration
 ✓ checking ssl: ECDSA P-384 cert works correctly
 ✓ checking logs: /var/log/mail.err in mailserver_ecdsa does not exist

4 tests, 0 failures
```

i can confirm from another test install that the spf.lua error message is a soft failure, as it still loads the spf.lua : 

```
582:2024-01-02 16:02:38 #1173(main) <tmg4rr>; cfg; rspamd_init_lua_filters: init of /usr/share/rspamd/lualib/lua_ffi/spf.lua failed: /usr/share/rspamd/lualib/lua_ffi/spf.lua:71: size of C type is unknown or too large at line 35; trace: [1]:{[C]:-1 - cdef [C]}; [2]:{/usr/share/rspamd/lualib/lua_ffi/spf.lua:71 - <unknown> [main]};
583:2024-01-02 16:02:38 #1173(main) <tmg4rr>; cfg; rspamd_init_lua_filters: init lua module spf from /usr/share/rspamd/spf.lua; digest: 864ad0d3be
```
