### PR TITLE
Add option to have ClamAV clamd use less memory on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Thank you very much.
 
 - [mailserver2/mailserver](#mailserver2mailserver)
   - [Fork](#fork)
-  - [Chat & questions](#chat--questions)
+  - [Chat \& questions](#chat--questions)
   - [Build](#build)
   - [Docker image](#docker-image)
   - [Summary](#summary)
@@ -86,6 +86,7 @@ Thank you very much.
   - [IPv6 support](#ipv6-support)
   - [Persistent files and folders in /mnt/docker/mail Docker volume](#persistent-files-and-folders-in-mntdockermail-docker-volume)
   - [Override postfix configuration](#override-postfix-configuration)
+  - [Whitelist Hosts/IP Addresses In Postfix](#whitelist-hostsip-addresses-in-postfix)
   - [Custom configuration for Dovecot](#custom-configuration-for-dovecot)
   - [Postfix blacklist](#postfix-blacklist)
   - [Email client settings](#email-client-settings)
@@ -113,6 +114,9 @@ Please check, if your system meets the following minimum requirements:
 | ---- | -------------- | ----------- |
 | CPU  | 1 GHz          | 1 GHz       |
 | RAM  | 512 MiB        | 1 GiB       |
+
+**NOTE**: If you are having problems with clamd using too much memory on startup, set `CLAMD_MEMORY_FIX` to `true`.
+See [the ClamAV documentation](https://docs.clamav.net/manual/Installing/Docker.html#what-can-i-do-to-minimize-ram-usage) for details.
 
 <p align="right"><a href="#summary">Back to table of contents :arrow_up_small:</a></p>
 
@@ -331,6 +335,7 @@ If you use Ansible, I recommend you to go to see [@ksylvan](https://github.com/k
 | **WHITELIST_SPAM_ADDRESSES**     | List of whitelisted email addresses separated by commas                                  | *optional*          | null                  |
 | **DISABLE_RSPAMD_MODULE**        | List of disabled modules separated by commas                                             | *optional*          | null                  |
 | **DISABLE_CLAMAV**               | Disable virus scanning                                                                   | *optional*          | false                 |
+| **CLAMD_MEMORY_FIX**             | Will add `ConcurrentDatabaseReload no` in clamd.conf                                     | *optional*          | false                 |
 | **DISABLE_SIEVE**                | Disable ManageSieve protocol                                                             | *optional*          | false                 |
 | **DISABLE_SIGNING**              | Disable DKIM/ARC signing                                                                 | *optional*          | false                 |
 | **DISABLE_GREYLISTING**          | Disable greylisting policy                                                               | *optional*          | false                 |
@@ -1123,7 +1128,7 @@ NOQUEUE: reject: 554 5.7.1 <john.doe@domain.tld>: Sender address rejected: Acces
 - Dovecot 2.2.27
 - Rspamd 1.9.4
 - Fetchmail 6.3.26
-- ClamAV 0.100.3
+- ClamAV 1.0.3
 - Clamav Unofficial Sigs 5.6.2
 - Zeyple 1.2.2
 - Unbound 1.6.0

--- a/rootfs/usr/local/bin/setup.sh
+++ b/rootfs/usr/local/bin/setup.sh
@@ -733,6 +733,10 @@ sed -i -e 's/^Foreground .*$/Foreground true/g' \
        -e 's/^LogFacility .*$/LogFacility LOG_MAIL/g' \
        /etc/clamav/clamd.conf
 
+if [ "$CLAMD_MEMORY_FIX" = true ]; then
+  echo "ConcurrentDatabaseReload no" >> /etc/clamav/clamd.conf
+fi
+
 # FRESHCLAM
 # ---------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Adds a new variable CLAMD_MEMORY_FIX to use the new ClamAV `ConcurrentDatabaseReload` option.

This reduces memory in the mailserver container on startup, with the downside that clamd will
block any new scans until reload is complete.

Fixes #63 

* The current behavior: out-of-memory crashes on my mailserver host.
* Desired behavior: Server is stable, no memory issues.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Status

- [X] Ready
- [ ] In development
- [ ] Hold

## How has this been tested ?

Tested this on my production server.

So far, it seems to be working. The load spiked, but not as much as before, then settled back down.

Will keep testing and update the PR.

```
$ w
 23:46:19 up 10 min,  1 user,  load average: 0.08, 0.10, 0.06
USER     TTY      FROM             LOGIN@   IDLE   JCPU   PCPU WHAT
deploy   pts/0    76.132.225.162   23:35    1.00s  0.08s  0.00s w

$ docker-compose exec mailserver /bin/bash
root@mail:/# tail /etc/clamav/clamd.conf 
LogFile /var/log/clamav/clamav.log
LogTime true
LogFileUnlock false
LogFileMaxSize 0
Bytecode true
BytecodeSecurity TrustSigned
BytecodeTimeout 60000
OnAccessMaxFileSize 5M
TCPSocket 3310
ConcurrentDatabaseReload no
```
