### PR TITLE
attempt to fix: s6-svc: fatal: unable to control /services/rsyslogd

### DIFF
--- a/rootfs/services/_parent/run
+++ b/rootfs/services/_parent/run
@@ -12,6 +12,9 @@
 # 8. clamd     (antivirus, is launched after database update)
 # 9. watcher   (watches for cert file changes)
 
+# give s6-svscan time to start
+sleep 1
+
 s6-svc -u /services/rsyslogd && s6-svwait -u /services/rsyslogd
 s6-svc -u /services/unbound  && [ "$DISABLE_DNS_RESOLVER" = true ] || s6-svwait -u /services/unbound
 s6-svc -u /services/postfix  && s6-svwait -u /services/postfix


### PR DESCRIPTION
## Description

There seem to be a race condition that prevents mailserver starting on some machines. There is a disucssion in the linked issue.

Fixes #68 

This PR adds a small delay for `_parent` process so s6-supervise has time to start for other processes.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Status

- [X] Ready

## Todo List
- [X] Implementation
- [ ] Tests
- [ ] Documentation

## How has this been tested ?

I ran `docker compose up -d --force-recreate` before that change 5 times. Failed 4 times out five. I ran it 5 times after the change it succeded all 5 times.